### PR TITLE
Sort options

### DIFF
--- a/jenkix/jenkix.sh
+++ b/jenkix/jenkix.sh
@@ -231,20 +231,20 @@ get_service() {
 #################################################################################
 
 #################################################################################
-while getopts "s::a:s:uphvj:" OPTION; do
+while getopts ":a:hj:s:v" OPTION; do
     case ${OPTION} in
+	a)
+	    ARGS[${#ARGS[*]}]=${OPTARG//p=}
+	    ;;
 	h)
 	    usage
-	    ;;
-	s)
-	    SECTION="${OPTARG}"
 	    ;;
         j)
             JSON=1
             IFS=":" JSON_ATTR=(${OPTARG//p=})
             ;;
-	a)
-	    ARGS[${#ARGS[*]}]=${OPTARG//p=}
+	s)
+	    SECTION="${OPTARG}"
 	    ;;
 	v)
 	    version


### PR DESCRIPTION
Sorting options alphabeticaly in getopts' optstring and the while loop is easier to follow and helps against double declaration and missing options.

While here remove the first `s` that is messing with the leading colon.
In some ksh implementation a double colon means the argument is
optional, which is probably not what was desired here. Unused options
have also been removed from the optstring.